### PR TITLE
Fix "The DDEV_URL variable is not set."

### DIFF
--- a/config/.ddev/docker-compose.chrome.yml
+++ b/config/.ddev/docker-compose.chrome.yml
@@ -8,7 +8,6 @@ services:
     # These labels ensure this service is discoverable by ddev
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: $DDEV_APPROOT
-      com.ddev.app-url: $DDEV_URL
   # This links the Chromedriver service to the web service defined
   # in the main docker-compose.yml, allowing applications running
   # in the web service to access the driver at `chrome`.


### PR DESCRIPTION
As mentioned in https://github.com/drud/ddev/issues/1701#issuecomment-509627439 `DDEV_URL` safely can be removed as it's unused now.

Resolves #2