### PR TITLE
Update docker-compose.chrome.yml for M1 Macs

### DIFF
--- a/config/.ddev/docker-compose.chrome.yml
+++ b/config/.ddev/docker-compose.chrome.yml
@@ -3,7 +3,7 @@ services:
   chrome:
     hostname: chrome
     container_name: ddev-${DDEV_SITENAME}-chrome
-    image: yukinying/chrome-headless-browser:64.0.3282.24
+    image: isholgueras/chrome-headless:latest
     labels:
     # These labels ensure this service is discoverable by ddev
       com.ddev.site-name: ${DDEV_SITENAME}


### PR DESCRIPTION
change image to isholgueras/chrome-headless:latest for M1 macs